### PR TITLE
build:weex对应的代码，少了一个空格

### DIFF
--- a/docs/prepare/build.md
+++ b/docs/prepare/build.md
@@ -13,7 +13,7 @@ Vue.js 源码是基于 [Rollup](https://github.com/rollup/rollup) 构建的，�
   "script": {
     "build": "node scripts/build.js",
     "build:ssr": "npm run build -- web-runtime-cjs,web-server-renderer",
-    "build:weex": "npm run build --weex"
+    "build:weex": "npm run build -- weex"
   }
 }
  


### PR DESCRIPTION
build:weex对应的代码，少了一个空格(在--和weex之间)