### PR TITLE
fix: define getters parameters name write wrong

### DIFF
--- a/docs/vuex/api.md
+++ b/docs/vuex/api.md
@@ -29,7 +29,7 @@ function installModule (store, rootState, path, module, hot) {
 
 ````js
 getters: {
-  total (state, getters, localState, localGetters) {
+  total (state, getters, rootState, rootGetters) {
     // 可访问全局 state 和 getters，以及如果是在 modules 下面，可以访问到局部 state 和 局部 getters
     return state.a + state.b
   }


### PR DESCRIPTION
定义getters时，注入的四个参数分别为 local.state、local.getters、store.state、store.getters。
所以此处第三、第四个参数的命名应该由 localState, localGetters 替换为 rootState，rootGetters。否则有歧义。
谢谢。